### PR TITLE
change rand object in LDPC_utils

### DIFF
--- a/consensus/eccpow/LDPC_utils.go
+++ b/consensus/eccpow/LDPC_utils.go
@@ -107,9 +107,11 @@ func generateH(parameters Parameters) [][]int {
 			colOrder = append(colOrder, j)
 		}
 
-		rand.Seed(hSeed)
-		rand.Shuffle(len(colOrder), func(i, j int) {
-			colOrder[i], colOrder[j] = colOrder[j], colOrder[i]
+		src := rand.NewSource(hSeed)
+		rnd := rand.New(src)
+		rnd.Seed(hSeed)
+		rnd.Shuffle(len(colOrder), func(i, j int) {
+			colOrder[i],colOrder[j] = colOrder[j], colOrder[i]
 		})
 		hSeed--
 


### PR DESCRIPTION
The problem occurred because all block validations share the same Random object. Validation errors occur because other block validations change rand object's seed .

We modified the code to use a different random object for each validation.